### PR TITLE
attempt to fix hotspot with password in Focal

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -71,6 +71,7 @@ PRODUCT_COPY_FILES += \
     $(DEVICE_PATH)/rootdir/system/halium/etc/apparmor.d/local/usr.bin.media-hub-server:system/halium/etc/apparmor.d/local/usr.bin.media-hub-server \
     $(DEVICE_PATH)/rootdir/system/halium/etc/default/usb-moded.d/device-specific-config.conf:system/halium/etc/default/usb-moded.d/device-specific-config.conf \
     $(DEVICE_PATH)/rootdir/system/halium/etc/NetworkManager/conf.d/fix-ap-with-password.conf:system/halium/etc/NetworkManager/conf.d/fix-ap-with-password.conf \
+    $(DEVICE_PATH)/rootdir/system/halium/etc/NetworkManager/conf.d/.halium-overlay-dir:system/halium/etc/NetworkManager/conf.d/.halium-overlay-dir \
     $(DEVICE_PATH)/rootdir/system/halium/etc/init/bluetooth-touch-android.conf:system/halium/etc/init/bluetooth-touch-android.conf \
     $(DEVICE_PATH)/rootdir/system/halium/usr/share/bluetooth-touch/android.sh:system/halium/usr/share/bluetooth-touch/android.sh \
     $(DEVICE_PATH)/rootdir/system/halium/usr/share/apparmor/hardware/graphics.d/apparmor-easyprof-ubuntu_android:system/halium/usr/share/apparmor/hardware/graphics.d/apparmor-easyprof-ubuntu_android \

--- a/device.mk
+++ b/device.mk
@@ -70,6 +70,7 @@ PRODUCT_COPY_FILES += \
     $(DEVICE_PATH)/rootdir/system/halium/etc/ubuntu-touch-session.d/android.conf:system/halium/etc/ubuntu-touch-session.d/android.conf \
     $(DEVICE_PATH)/rootdir/system/halium/etc/apparmor.d/local/usr.bin.media-hub-server:system/halium/etc/apparmor.d/local/usr.bin.media-hub-server \
     $(DEVICE_PATH)/rootdir/system/halium/etc/default/usb-moded.d/device-specific-config.conf:system/halium/etc/default/usb-moded.d/device-specific-config.conf \
+    $(DEVICE_PATH)/rootdir/system/halium/etc/NetworkManager/conf.d/fix-ap-with-password.conf:system/halium/etc/NetworkManager/conf.d/fix-ap-with-password.conf \
     $(DEVICE_PATH)/rootdir/system/halium/etc/init/bluetooth-touch-android.conf:system/halium/etc/init/bluetooth-touch-android.conf \
     $(DEVICE_PATH)/rootdir/system/halium/usr/share/bluetooth-touch/android.sh:system/halium/usr/share/bluetooth-touch/android.sh \
     $(DEVICE_PATH)/rootdir/system/halium/usr/share/apparmor/hardware/graphics.d/apparmor-easyprof-ubuntu_android:system/halium/usr/share/apparmor/hardware/graphics.d/apparmor-easyprof-ubuntu_android \

--- a/rootdir/system/halium/etc/NetworkManager/conf.d/fix-ap-with-password.conf
+++ b/rootdir/system/halium/etc/NetworkManager/conf.d/fix-ap-with-password.conf
@@ -1,0 +1,2 @@
+[main]
+wifi-wpa-psk-pmf-no-optional-ap=yes


### PR DESCRIPTION
I have made hotspot with password to work on my phone by adding a file to /etc/Networkmanager, [just like was done for Volla phone ](https://gitlab.com/ubports/porting/reference-device-ports/android9/volla-phone/volla-yggdrasil/-/issues/7)
For the fix to get into the device repo I created a commit essentially copying what was done in [this previous one ](https://github.com/fredldotme/device-sony-suzu/pull/4/commits/c70b5150f6835664145d2e186ca908c50359dc16). I hope that is appropriate, as I really don't understand the full picture.